### PR TITLE
Fix a issue for "Re-opens Firefox when rebuilding"

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ WebpackWebExt.prototype.runWebExtCommand = function() {
 
 WebpackWebExt.prototype.apply = function(compiler) {
   compiler.plugin('emit', (compilation, callback) => {
-    if (this.runOnce && !this.webExtRunPromise) {
+    if (this.runOnce) {
       if (!this.webExtRunPromise) {
         this.webExtRunPromise = this.runWebExtCommand();
       }


### PR DESCRIPTION
Even if I set runOnce = true, firefox instance pops up each rebuilding process.
This commit fixes the issue.